### PR TITLE
feat: add password protection for relay connections (#14)

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -42,6 +42,11 @@ program
     new Option('-T, --listener-target-port <number>', 'target port for listener').env('HSYNC_LTP')
   )
   .addOption(
+    new Option('--listener-password <string>', 'password for connecting to relay').env(
+      'HSYNC_LPWD'
+    )
+  )
+  .addOption(
     new Option('-R, --relay-inbound-port <number>', 'inbound port for remote relay requests').env(
       'HSYNC_RIP'
     )
@@ -71,6 +76,11 @@ program
     ).env('HSYNC_RBL')
   )
   .addOption(
+    new Option('--relay-password <string>', 'password required to connect to this relay').env(
+      'HSYNC_RPWD'
+    )
+  )
+  .addOption(
     new Option('-x, --shell', 'shell to localhost and --port for piping data to a listener')
   );
 
@@ -94,6 +104,9 @@ if (options.shell) {
   if (options.listenerTargetPort) {
     options.listenerTargetPort = options.listenerTargetPort.split(',').map((p) => Number(p));
   }
+  if (options.listenerPassword) {
+    options.listenerPassword = options.listenerPassword.split(',');
+  }
 
   if (options.relayInboundPort) {
     options.relayInboundPort = options.relayInboundPort.split(',').map((p) => Number(p));
@@ -103,6 +116,9 @@ if (options.shell) {
   }
   if (options.relayTargetPort) {
     options.relayTargetPort = options.relayTargetPort.split(',').map((p) => Number(p));
+  }
+  if (options.relayPassword) {
+    options.relayPassword = options.relayPassword.split(',');
   }
 
   // console.log('options', options);

--- a/connection.js
+++ b/connection.js
@@ -38,6 +38,8 @@ export async function createHsync(config) {
     relayInboundPort,
     relayTargetHost,
     relayTargetPort,
+    listenerPassword,
+    relayPassword,
   } = config;
   const { dynamicHost } = config;
   let { hsyncServer, hsyncSecret } = config;
@@ -267,7 +269,8 @@ export async function createHsync(config) {
           lth = lth.substring(0, lth.length - 1);
         }
         const ltp = listenerTargetPort ? listenerTargetPort[i] : llp;
-        hsyncClient.addSocketListener({ port: llp, targetPort: ltp, targetHost: lth });
+        const lpwd = listenerPassword ? listenerPassword[i] || listenerPassword[0] : undefined;
+        hsyncClient.addSocketListener({ port: llp, targetPort: ltp, targetHost: lth, password: lpwd });
         debug('relaying local', llp, 'to', lth, ltp);
       }
     });
@@ -283,7 +286,8 @@ export async function createHsync(config) {
           rth = rth.substring(0, rth.length - 1);
         }
         const rtp = relayTargetPort ? relayTargetPort[i] : rip;
-        hsyncClient.addSocketRelay({ port: rip, targetHost: rth, targetPort: rtp });
+        const rpwd = relayPassword ? relayPassword[i] || relayPassword[0] : undefined;
+        hsyncClient.addSocketRelay({ port: rip, targetHost: rth, targetPort: rtp, password: rpwd });
         debug('relaying inbound', rip, 'to', rth, rtp);
       }
     });
@@ -291,3 +295,4 @@ export async function createHsync(config) {
 
   return hsyncClient;
 }
+

--- a/lib/socket-listeners.js
+++ b/lib/socket-listeners.js
@@ -31,7 +31,7 @@ export function initListeners(hsyncClient) {
   }
 
   function addSocketListener(options = {}) {
-    const { port, targetPort, targetHost } = options;
+    const { port, targetPort, targetHost, password } = options;
     if (!targetHost) {
       throw new Error('no targetHost');
     }
@@ -43,7 +43,7 @@ export function initListeners(hsyncClient) {
     if (url.hostname.toLowerCase() === hsyncClient.myHostName.toLowerCase()) {
       throw new Error('targetHost must be a different host');
     }
-    debug('creating handler', port, cleanHost);
+    debug('creating handler', port, cleanHost, password ? '(with password)' : '');
     if (cleanHost !== targetHost) {
       debug('targetHost cleaned UP', targetHost, cleanHost);
     }
@@ -134,6 +134,7 @@ export function initListeners(hsyncClient) {
           socketId: socket.socketId,
           port: targetPort || port,
           hostName: rpcPeer.hostName,
+          password: password || undefined,
         });
         debug('connect result', result);
         socket.peerConnected = true;
@@ -170,6 +171,7 @@ export function initListeners(hsyncClient) {
       targetHost: cleanHost,
       targetPort: targetPort || port,
       port,
+      hasPassword: !!password,
     };
 
     socketListeners['p' + port] = listener;

--- a/lib/socket-relays.js
+++ b/lib/socket-relays.js
@@ -27,12 +27,14 @@ export function initRelays(hsyncClient) {
         whitelist: l.whitelist || '',
         blacklist: l.blacklist || '',
         hostName: l.targetHost,
+        // Note: password is intentionally not exposed in listing
+        hasPassword: !!l.password,
       };
     });
     return retVal;
   }
 
-  function connectSocket(peer, { port, socketId, hostName }) {
+  function connectSocket(peer, { port, socketId, hostName, password }) {
     debug('connectSocket', port, socketId, hostName);
 
     peer.notifications.oncloseRelaySocket((peer, { socketId }) => {
@@ -49,6 +51,17 @@ export function initRelays(hsyncClient) {
     debug('connect relay', port, socketId, peer.hostName);
     if (!relay) {
       throw new Error('no relay found for port: ' + port);
+    }
+
+    // Check password if relay requires one
+    if (relay.password) {
+      if (!password) {
+        throw new Error('relay requires password');
+      }
+      if (password !== relay.password) {
+        throw new Error('invalid relay password');
+      }
+      debug('relay password verified for port', port);
     }
 
     //  TODO: check white and black lists on peer
@@ -92,10 +105,10 @@ export function initRelays(hsyncClient) {
     });
   }
 
-  function addSocketRelay({ whitelist, blacklist, port, targetPort, targetHost }) {
+  function addSocketRelay({ whitelist, blacklist, port, targetPort, targetHost, password }) {
     targetPort = targetPort || port;
     targetHost = targetHost || 'localhost';
-    debug('creating relay', whitelist, blacklist, port, targetPort, targetHost);
+    debug('creating relay', whitelist, blacklist, port, targetPort, targetHost, password ? '(with password)' : '(no password)');
     const newRelay = {
       whitelist,
       blacklist,
@@ -103,6 +116,7 @@ export function initRelays(hsyncClient) {
       targetPort,
       targetHost,
       hostName: targetHost,
+      password: password || null,
     };
     cachedRelays['p' + port] = newRelay;
     return newRelay;


### PR DESCRIPTION
## Summary

Fixes #14 - adds optional password protection for relay connections.

## Changes

### lib/socket-relays.js
- Add `password` parameter to `addSocketRelay()`
- Verify password in `connectSocket()` before allowing connection
- Expose `hasPassword` in relay listing (without actual password)

### lib/socket-listeners.js
- Add `password` parameter to `addSocketListener()`
- Pass password when calling remote `connectSocket()`

### connection.js
- Wire `listenerPassword` and `relayPassword` config options through

### cli.js
- Add `--relay-password` flag (env: HSYNC_RPWD)
- Add `--listener-password` flag (env: HSYNC_LPWD)

## Usage

```bash
# Create password-protected relay
hsync -R 8080 --relay-password mySecret

# Connect to password-protected relay
hsync -L 8080 -H hsync://remote.host --listener-password mySecret
```

## Security Notes

- Passwords transmitted over existing encrypted channel
- Never logged or exposed in listings
- Invalid password = connection rejected with error