### PR TITLE
fix(security): use crypto.randomBytes for RPC auth tokens (#26)

### DIFF
--- a/lib/peers.js
+++ b/lib/peers.js
@@ -1,3 +1,4 @@
+import crypto from 'node:crypto';
 import rawr from 'rawr';
 import b64id from 'b64id';
 import createDebug from 'debug';
@@ -47,7 +48,7 @@ export function initPeers(hsyncClient) {
       debug('CREATING peer', hostName);
       peer = createRPCPeer({ hostName, hsyncClient: this, timeout });
       peerLib.emit('peerCreated', peer);
-      peer.myAuth = b64id.generateId();
+      peer.myAuth = crypto.randomBytes(32).toString('base64url');
       if (temporary) {
         peer.rpcTemporary = true;
       }
@@ -64,7 +65,7 @@ export function initPeers(hsyncClient) {
     if (hostName === hsyncClient.myHostName) {
       throw new Error('Peer must be a different host');
     }
-    const myAuth = b64id.generateId();
+    const myAuth = crypto.randomBytes(32).toString('base64url');
     const transport = new EventEmitter();
     const peer = rawr({
       transport,


### PR DESCRIPTION
## Summary

Fixes #26 - Critical security vulnerability in peer authentication.

## Problem

`b64id.generateId()` produces predictable IDs that were being used as auth tokens (`myAuth`) for peer validation. These tokens are transmitted in plaintext, making peer impersonation trivial.

## Solution

Replace `b64id.generateId()` with `crypto.randomBytes(32).toString("base64url")` for `myAuth` token generation in both `createRPCPeer` and `getRPCPeer`.

- Uses Node.js built-in `crypto` module (no new dependencies)
- 256 bits of cryptographic randomness per token
- `b64id.generateId()` retained for non-security uses (RPC message id generation)

## Testing

- ESLint: ✅ passes
- Vitest: ✅ all 158 tests pass (7 test files)

## Reviewer

@Luthien - mandatory security review